### PR TITLE
Feature/add refunds support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ A Redsys~~Sermepa~~ payment gateway backend for [django-payments](https://github
   * "obtained by accessing the Administration Module, Merchant Data Query option in the 'See Key' section"
 * currency (default:'978'): ISO-4217 currency code.
   * For example: EUR: '978', GBP: '826', USD: '840' (source: https://en.wikipedia.org/wiki/ISO_4217#Active_codes).
-* endpoint (default:'https://sis-t.redsys.es:25443/sis/realizarPago': desired endpoint.
-  * Sandbox endpoint is default. Production endpoint is https://sis.redsys.es/sis/realizarPago
+* endpoint (default:'https://sis-t.redsys.es:25443': desired endpoint.
+  * Sandbox endpoint is default. Production endpoint is 'https://sis.redsys.es'
 * order_number_prefix (default:'0000'): Payment PK is suffixed to this to create Redsys order number
 * signature_version (default:'HMAC_SHA256_V1'): Only supported signature type.
 

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -109,11 +109,13 @@ class RedsysProvider(BasicProvider):
         }
         return data
 
-    '''
     def refund(self, payment, amount=None):
-        refund_amount = payment.captured_amount if amount is None else amount
-        cents = str(refund_amount.quantize(CENTS, rounding=ROUND_HALF_UP))
-        order_number = '%s%d' % (self.order_number_prefix,payment.pk)
+        refund_amount = amount or payment.captured_amount
+        # cents = str(int(
+        #     refund_amount.quantize(CENTS, rounding=ROUND_HALF_UP)) * 100
+        # )
+        cents = str(int(refund_amount * 100))
+        order_number = '%s%d' % (self.order_number_prefix, payment.pk)
         merchant_data = {
             "DS_MERCHANT_AMOUNT": cents,
             "DS_MERCHANT_ORDER": order_number,

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -135,6 +135,12 @@ class RedsysProvider(BasicProvider):
         }
 
         response = self.post(payment, self.endpoint, data=data)
+        # Redsys "always" return a 200 with HTML content...
+        if response and response.status_code == 200:
+            # dirty way to confirm if refund has been achieved...
+            if "RSisReciboOK" in response.text and \
+                "operacionAceptada" in response.text:
+                return refund_amount
 
     def get_form(self, payment, data=None):
         return PaymentForm(self.get_hidden_fields(payment),

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -130,6 +130,12 @@ class RedsysProvider(BasicProvider):
         return data
 
     def refund(self, payment, amount=None):
+        """
+        It requests a refund to Redsys using their Webservices layer
+
+        More information about the process and the error codes at
+        https://canales.redsys.es/canales/ayuda/documentacion/Manual%20integracion%20para%20conexion%20por%20Web%20Service.pdf
+        """
         refund_amount = amount or payment.captured_amount
         # cents = str(int(
         #     refund_amount.quantize(CENTS, rounding=ROUND_HALF_UP)) * 100

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -79,7 +79,11 @@ class RedsysProvider(BasicProvider):
         self.shared_secret = kwargs.pop('shared_secret')
         self.currency = kwargs.pop('currency', '978')
 
-        self.endpoint = kwargs.pop('endpoint', REDSYS_ENVIRONMENTS.get('pruebas'))
+        # Get provided endpoint base domain or REDSYS.pruebas env
+        self.endpoint = urljoin(
+            kwargs.pop('endpoint', REDSYS_ENVIRONMENTS.get('pruebas')),
+            "",
+        )
         assert self.endpoint in REDSYS_ENVIRONMENTS.values(), \
             "Provided Redsys endpoint '{}' is not valid".format(self.endpoint)
 

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -91,6 +91,11 @@ class RedsysProvider(BasicProvider):
     def endpoint_form(self):
         return "{}/sis/realizarPago".format(self.endpoint)
 
+    @property
+    def endpoint_wsdl(self):
+        return "{}/sis/services/SerClsWSEntrada/wsdl/SerClsWSEntrada.wsdl".format(self.endpoint)
+
+    def post(self, *args, **kwargs):
     def get_hidden_fields(self, payment):
         #site = Site.objects.get_current()
         order_number = '%s%d' % (self.order_number_prefix,payment.pk)

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -151,9 +151,18 @@ class RedsysProvider(BasicProvider):
             "DS_MERCHANT_TERMINAL": self.terminal,
             "DS_MERCHANT_MERCHANTURL": self.get_return_url(payment),
         }
-        json_data = json.dumps(merchant_data)
-        b64_params = base64.b64encode(json_data.encode())
-        signature = compute_signature(str(order_number), b64_params, self.shared_secret)
+
+        # Prepare the signature
+        signature_data = xmltodict.unparse(
+            {"DATOSENTRADA": merchant_data},
+            full_document=False,
+        )
+        b64_params = base64.b64encode(signature_data.encode())
+        signature = compute_signature(
+            str(order_number),
+            signature_data.encode(), 
+            self.shared_secret
+        )
         data = {
             'Ds_SignatureVersion': self.signature_version,
             'Ds_MerchantParameters': b64_params.decode(),

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -197,7 +197,7 @@ class RedsysProvider(BasicProvider):
 
     def get_form(self, payment, data=None):
         return PaymentForm(self.get_hidden_fields(payment),
-                           self.endpoint, self._method)
+                           self.endpoint_form, self._method)
 
     def process_data(self, payment, request):
         form = RedsysResponseForm(request.POST)

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -33,6 +33,7 @@ from django.shortcuts import redirect
 
 from payments.forms import PaymentForm
 from payments.core import BasicProvider, get_base_url, urljoin
+from payments import PaymentError
 
 from django import forms
 
@@ -141,6 +142,8 @@ class RedsysProvider(BasicProvider):
             if "RSisReciboOK" in response.text and \
                 "operacionAceptada" in response.text:
                 return refund_amount
+
+        raise PaymentError("Redsys doesn't accept the refund")
 
     def get_form(self, payment, data=None):
         return PaymentForm(self.get_hidden_fields(payment),

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -96,6 +96,9 @@ class RedsysProvider(BasicProvider):
         return "{}/sis/services/SerClsWSEntrada/wsdl/SerClsWSEntrada.wsdl".format(self.endpoint)
 
     def post(self, *args, **kwargs):
+        client = zeep.Client(*args) 
+        return client.service.trataPeticion(kwargs.get('data', {}))
+
     def get_hidden_fields(self, payment):
         #site = Site.objects.get_current()
         order_number = '%s%d' % (self.order_number_prefix,payment.pk)

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -193,7 +193,7 @@ class RedsysProvider(BasicProvider):
             # Wait to raise 
             pass
 
-        raise PaymentError("Redsys doesn't accept the refund")
+        raise PaymentError("Redsys error '{}'".format(response_code or "non matched response"))
 
     def get_form(self, payment, data=None):
         return PaymentForm(self.get_hidden_fields(payment),

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -65,6 +65,12 @@ class RedsysResponseForm(forms.Form):
     Ds_Signature = forms.CharField(max_length=256)
     Ds_MerchantParameters = forms.CharField(max_length=2048)
 
+# TODO: Will be great to reach the endpoint just using "real" or "pruebas", but will be a major update
+REDSYS_ENVIRONMENTS = {
+    "real": "https://sis.redsys.es",
+    "pruebas": "https://sis-t.redsys.es:25443",
+}
+
 class RedsysProvider(BasicProvider):
     def __init__(self, *args, **kwargs):
         self.merchant_code = kwargs.pop('merchant_code')

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -77,7 +77,11 @@ class RedsysProvider(BasicProvider):
         self.terminal = kwargs.pop('terminal')
         self.shared_secret = kwargs.pop('shared_secret')
         self.currency = kwargs.pop('currency', '978')
-        self.endpoint = kwargs.pop('endpoint', 'https://sis-t.redsys.es:25443/sis/realizarPago')
+
+        self.endpoint = kwargs.pop('endpoint', REDSYS_ENVIRONMENTS.get('pruebas'))
+        assert self.endpoint in REDSYS_ENVIRONMENTS.values(), \
+            "Provided Redsys endpoint '{}' is not valid".format(self.endpoint)
+
         self.order_number_prefix = kwargs.pop('order_number_prefix','0000')
         self.signature_version = kwargs.pop('signature_version','HMAC_SHA256_V1')
         #TODO self.button_image = '/static/images/payment_button.jpg'

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -163,11 +163,20 @@ class RedsysProvider(BasicProvider):
             signature_data.encode(), 
             self.shared_secret
         )
+
+        # Prepare the resultant XML
         data = {
-            'Ds_SignatureVersion': self.signature_version,
-            'Ds_MerchantParameters': b64_params.decode(),
-            'Ds_Signature': signature.decode(),
+            "REQUEST": {
+                "DATOSENTRADA": merchant_data,
+                'DS_SIGNATUREVERSION': self.signature_version,
+                'DS_SIGNATURE': signature.decode(),
+            },
         }
+        data_xml = xmltodict.unparse(data)
+        response = self.post(
+            self.endpoint_wsdl,
+            data=data_xml,
+        )
 
         response = self.post(payment, self.endpoint, data=data)
         # Redsys "always" return a 200 with HTML content...

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -27,6 +27,7 @@ import pyDes
 
 from codecs import encode
 
+import requests
 from django.http import HttpResponse
 from django.shortcuts import redirect
 
@@ -74,6 +75,9 @@ class RedsysProvider(BasicProvider):
         self.signature_version = kwargs.pop('signature_version','HMAC_SHA256_V1')
         #TODO self.button_image = '/static/images/payment_button.jpg'
         super(RedsysProvider, self).__init__(*args, **kwargs)
+
+    def post(self, payment, *args, **kwargs):
+        return requests.post(*args, **kwargs)
 
     def get_hidden_fields(self, payment):
         #site = Site.objects.get_current()

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -133,9 +133,8 @@ class RedsysProvider(BasicProvider):
             'Ds_MerchantParameters': b64_params.decode(),
             'Ds_Signature': signature.decode(),
         }
-        # now need to post this to redsys...
-        return amount
-    '''
+
+        response = self.post(payment, self.endpoint, data=data)
 
     def get_form(self, payment, data=None):
         return PaymentForm(self.get_hidden_fields(payment),

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -87,8 +87,9 @@ class RedsysProvider(BasicProvider):
         #TODO self.button_image = '/static/images/payment_button.jpg'
         super(RedsysProvider, self).__init__(*args, **kwargs)
 
-    def post(self, payment, *args, **kwargs):
-        return requests.post(*args, **kwargs)
+    @property
+    def endpoint_form(self):
+        return "{}/sis/realizarPago".format(self.endpoint)
 
     def get_hidden_fields(self, payment):
         #site = Site.objects.get_current()

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -16,10 +16,12 @@
 # along with django-payments-redsys.  If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
+import zeep
 import hashlib
 import datetime
 import json
 import re
+import xmltodict
 
 import base64
 import hmac
@@ -27,7 +29,6 @@ import pyDes
 
 from codecs import encode
 
-import requests
 from django.http import HttpResponse
 from django.shortcuts import redirect
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Django>=1.11
+django-payments>=0.12.3
+pyDes>=2.0.0
+xmltodict
+zeep

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     description='A django-payments backend for the Redsys payment gateway',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='0.3.post1',
+    version='0.4',
     url='https://github.com/ajostergaard/django-payments-redsys',
     packages=PACKAGES,
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ REQUIREMENTS = [
     'Django>=1.11',
     'django-payments>=0.12.3',
     'pyDes>=2.0.0',
+    'xmltodict',
+    'zeep',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ REQUIREMENTS = [
     'zeep',
 ]
 
+with open('requirements.txt', 'r') as f:
+    REQUIREMENTS = f.readlines()
+
 setup(
     name='django-payments-redsys',
     author='AJ Ostergaard',

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Topic :: Software Development :: Libraries :: Application Frameworks',


### PR DESCRIPTION
It provides `refund` support to Redsys provider for Django Payments.

This requests to Redsys the refund (`DS_MERCHANT_TRANSACTIONTYPE = 3`) using the base `payment.refund(payment, amount)` method.

Amount is optional, if not provided uses the full `payment.captured_amount`.

~~The result is dirty-parsed to identify if the refund has accepted or not (raising a PaymentError exception); in a short will be moved to use the XML/SOAP API instead of directly POST it.~~

Integrates PR #2: Instead of POSTing the refund and dirty-parse the result, it dispatchs the refund request through the RedSys SOAP layer.

Also, the endpoint is defined using just the base domain (protocol, domain and port). If resource URLs are provided as endpoint are cleaned to provide compatibility with old-style endpoints.

Finally, a requirements file is provided to humanize the definition of installation requirements.

It bumps to v0.4!

Fix #9 Support refunds